### PR TITLE
Add zaporylie/composer-drupal-optimizations.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "mikey179/vfsstream": "^1.2",
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^3.4.0",
-        "symfony/css-selector": "^2.8"
+        "symfony/css-selector": "^2.8",
+        "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
### For the PR creator:
Check off the following boxes before asking someone to review this PR.

- [x] If this PR changes the `composer.json` file, is there accompanying text in the `README.md` file explaining that change?
Seems unnecessary
- [x] Update the "How to test this branch" instructions below by replacing `[the-branch]` with the name of this branch, and 
`[the-new-project]` with an example project name.

### What this PR does:
Adds zaporylie/composer-drupal-optimizations to the dev requirements to prevent PHP out of memory errors when running composer.

### How to test this branch:
- [ ] If you haven't already, run the [One time setup steps](https://github.com/United-Philanthropy-Forum/km-starter-kit/wiki/How-to-test-changes-to-this-starter-kit#one-time)
- [ ] Run "composer install"
- [ ] Run "composer require drupal/leaflet" and confirm you don't get an out-of-memory error.

```yaml
terminus build:project:create --team='United Philanthropy Forum' --org='United-Philanthropy-Forum' --visibility='private' --stability=dev "united-philanthropy-forum/km-starter-kit:dev-composer_drupal" kmc-composer
```

- [ ] Validate that a new site exists at https://dev-kmc-composer.pantheonsite.io
- [ ] Validate the repo exists at https://github.com/United-Philanthropy-Forum/kmc-composer
- [ ] Delete the test environment when you're done, by running `terminus build:env:obliterate kmc-composer`
