### PR TITLE
From km-collaborative #46 adding the ability for km-collaborative to …

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Check off the following boxes before asking someone to review this PR.
 - [ ] Run this:
 
 ```yaml
-terminus build:project:create --team='United Philanthropy Forum' --org='United-Philanthropy-Forum' --visibility='private' --stability=dev "united-philanthropy-forum/km-starter-kit:dev-[the-branch]" [the-new-project]
+COMPOSER_MEMORY_LIMIT=-1 terminus build:project:create --team='United Philanthropy Forum' --org='United-Philanthropy-Forum' --visibility='private' --stability=dev "united-philanthropy-forum/km-starter-kit:dev-[the-branch]" [the-new-project]
 ```
 
 - [ ] Validate that a new site exists at https://dev-[the-new-project].pantheonsite.io

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ This code was largely taken from the example drops repo, but was also largely cu
 * The "scripts/composer/ScriptUpdater.php" autoloader file was added, and the "DrupalProject\\composer\\ScriptUpdater::createParentFiles"
 command was added post install, update, and build.
 
+* The "united-philanthropy-forum/km_collaborative" package is added to the list of items that can pull in scaffold files. This allows km-collaborative the ability to push top-level useful files to all sites using it.
+
 * The "km-collab-scaffold" was added to the "extras" section. These are configurations passed to the "scripts/composer/ScriptUpdater.php" script.
 
 * The option to allow upstream modules to apply patches was enabled via the "enable-patching" section. This way, the [KM Collaboration profile](https://github.com/United-Philanthropy-Forum/km-collaborative) can be responsible for things like drupal core patches.

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,8 @@
         },
         "drupal-scaffold": {
             "allowed-packages": [
-                "pantheon-systems/drupal-integrations"
+                "pantheon-systems/drupal-integrations",
+                "united-philanthropy-forum/km_collaborative"
             ],
             "locations": {
                 "web-root": "./web"


### PR DESCRIPTION
- [x] Update the "How to test this branch" instructions below by replacing `[the-branch]` with the name of this branch, and 
`[the-new-project]` with an example project name.

### What this PR does:
- [ ] The "united-philanthropy-forum/km_collaborative" package is added to the list of items that can pull in scaffold files. This allows km-collaborative the ability to push top-level useful files to all sites using it. 

### How to test this branch:
- [x] If you haven't already, run the [One time setup steps](https://github.com/United-Philanthropy-Forum/km-starter-kit/wiki/How-to-test-changes-to-this-starter-kit#one-time)
- [x] Run this:

```yaml
COMPOSER_MEMORY_LIMIT=-1 terminus build:project:create --team='United Philanthropy Forum' --org='United-Philanthropy-Forum' --visibility='private' --stability=dev "united-philanthropy-forum/km-starter-kit:dev-km-collab-scaffolding" kmcstest
```

- [x] Validate that a new site exists at https://dev-kmcstest.pantheonsite.io
- [x] Validate the repo exists at https://github.com/United-Philanthropy-Forum/kmcstest
- [x] Clone that repository to your local machine. 
- [x] Do a `composer require united-philanthropy-forum/km_collaborative dev-develop`
- [x] Validate that you can run `drupal build` and see a fresh site on your local machine but NO changes to your config file's UUIDs. https://github.com/United-Philanthropy-Forum/km-collaborative/issues/46
- [x] Validate that there's a `.dependabot` folder in your project root (for https://github.com/United-Philanthropy-Forum/km-collaborative/issues/9 )
- [x] Delete the test environment when you're done, by running `terminus build:env:obliterate kmcstest`
- [ ] Once this PR is merged, cut a new tag so the `create-project` commands will get the latest and greatest.
