### PR TITLE
Issue #530 adding merge-plugin options to the starter kit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ command was added post install, update, and build.
 * The patchLevel was set to -p2 for the drupal/core package, which keeps a rouge "b" folder from showing up in your web/core folder in cases
 where the patch doesn't apply cleanly.
 
+* The merge-plugin options from the [composer-merge-plugin](https://github.com/wikimedia/composer-merge-plugin)
+  were added to allow the anchor_link module to include custom ckeditor packages not available via packagist.
+
 #### scripts/composer/ScriptHandler.php
 
 This is a direct copy of the same file in [the D8 pantheon drop](https://github.com/pantheon-systems/example-drops-8-composer) and will be overwritten by upstream changes on "create-project". This file needs to exist in this repo for the terminus build command to succeed, and it can be pulled from the drop to this repo directly at any time.

--- a/composer.json
+++ b/composer.json
@@ -157,6 +157,18 @@
         },
         "patchLevel": {
             "drupal/core": "-p2"
+        },
+        "merge-plugin": {
+            "include": [
+                "web/modules/contrib/anchor_link/composer.libraries.json"
+            ],
+            "recurse": true,
+            "replace": false,
+            "ignore-duplicates": false,
+            "merge-dev": false,
+            "merge-extra": false,
+            "merge-extra-deep": false,
+            "merge-scripts": false
         }
     },
     "config": {


### PR DESCRIPTION
### For the PR creator:
Check off the following boxes before asking someone to review this PR.

- [x] If this PR changes the `composer.json` file, is there accompanying text in the `README.md` file explaining that change?
- [x] Update the "How to test this branch" instructions below by replacing `[the-branch]` with the name of this branch, and 
`[the-new-project]` with an example project name.

### What this PR does:
- [ ] For https://github.com/United-Philanthropy-Forum/km-collaborative/issues/530. Because the [Anchor Link](https://www.drupal.org/project/anchor_link) module requires you to load ckeditor plugins not available in packagist, this adds a utility to the Extra section of the composer.json file that allows pulling in custom repositories from a composer.libraries.json path. This could also be applied to the webform module as both use the same approach to provide third-party libraries.

### How to test this branch:
- [ ] If you haven't already, run the [One time setup steps](https://github.com/United-Philanthropy-Forum/km-starter-kit/wiki/How-to-test-changes-to-this-starter-kit#one-time)
- [ ] Run this:

```yaml
COMPOSER_MEMORY_LIMIT=-1 terminus build:project:create --team='United Philanthropy Forum' --org='United-Philanthropy-Forum' --visibility='private' --stability=dev "united-philanthropy-forum/km-starter-kit:dev-issue-530-anchor-link-libraries" kmc-anchor
```

- [ ] Validate that a new site exists at https://dev-kmc-anchor.pantheonsite.io
- [ ] Validate the repo exists at https://github.com/United-Philanthropy-Forum/kmc-anchor
- [ ] Delete the test environment when you're done, by running `terminus build:env:obliterate kmc-anchor`
- [ ] Once this PR is merged, cut a new tag so the `create-project` commands will get the latest and greatest.
