### PR TITLE
Don't fail composer operations when npm fails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,8 +76,8 @@
             "DrupalProject\\composer\\ScriptUpdater::createParentFiles"
         ],
         "compile-code": [
-            "npm install --prefix web/profiles/contrib/km_collaborative/themes/kmc_base_theme",
-            "npm run build --prefix web/profiles/contrib/km_collaborative/themes/kmc_base_theme"
+            "npm install --prefix web/profiles/contrib/km_collaborative/themes/kmc_base_theme || true",
+            "npm run build --prefix web/profiles/contrib/km_collaborative/themes/kmc_base_theme || true"
         ],
         "post-drupal-scaffold-cmd": [
             "chmod 755 .ci/build/multidev-save && chmod 755 .ci/deploy/pantheon/dev-multidev"


### PR DESCRIPTION
Fixes this type of error when npm fails - we should be able to complete composer operations successfully even if our node environment is broken for some reason.

```
Script npm install --prefix web/themes/custom/ts_scgm handling the compile-code event returned with error code 1
Script @compile-code was called via post-update-cmd

Installation failed, reverting ./composer.json to its original content.
```