### PR TITLE
Remove kmc_config_part2 from the project creation process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Building this project successfully requires a few things:
     ```
 8. You have run the [One time setup steps](https://github.com/United-Philanthropy-Forum/km-starter-kit/wiki/How-to-test-changes-to-this-starter-kit#one-time)
 
-9. Your local machine is running php 7.4. You'll know this is working when you can type `php -v` into your console and see something like `PHP 7.4.29 (cli)`
+9. Your local machine is running php 8.1. You'll know this is working when you can type `php -v` into your console and see something like `PHP 8.1.12 (cli)`
 
 ### Usage:
 
@@ -77,6 +77,12 @@ https://github.com/United-Philanthropy-Forum/thinkshout-foundation
 https://dev-thinkshout-foundation.pantheonsite.io
 
 The Pantheon site should also have the km_collaborative profile installed.
+
+## Initial site setup
+
+If the above process completes successfully, you'll have a github repo and a Pantheon repo tied together with CircleCI, all in the appropriate Organizations or accounts. On Pantheon, you'll have a basic site installed on "dev", but it won't look like much, and it won't have most of the KMC features yet. In order to get these, you'll need to work around Pantheon's memory limits. The best way to do this is to create a local copy of the site and clone down the Pantheon database. In your local environment, disable your PHP memory limits (or set them very high). Then, enable the "kmc_config_part2" module. Once you have done so, export your database and import it on Pantheon.
+
+You may also want to enable some other kmc submodules, depending on your site requirements, like kmc_salesforce if you are integrating with a Salesforce instance using the KMC package. These can all be enabled directly on Pantheon once you have "kmc_config_part2" enabled -- that is the only module that needs excessive memory to install.
 
 ### What to do if the build:project command fails:
 

--- a/composer.json
+++ b/composer.json
@@ -163,13 +163,15 @@
     },
     "config": {
         "allow-plugins": {
-            "composer/*": true,
+            "composer/installers": true,
             "cweagans/composer-patches": true,
-            "drupal/*": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/console-extend-plugin": true,
+            "drupal/core-composer-scaffold": true,
             "oomphinc/composer-installers-extender": true,
             "wikimedia/composer-merge-plugin": true,
             "zaporylie/composer-drupal-optimizations": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "mnsami/composer-custom-directory-installer": true
         },
         "optimize-autoloader": true,
         "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^8.1",
-        "united-philanthropy-forum/km_collaborative": "dev-release-v180"
+        "united-philanthropy-forum/km_collaborative": "dev-install_fix"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": ">=0.5.0",

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,12 @@
             "./vendor/bin/phpcs --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md --ignore=node_modules,bower_components,vendor ./web/modules/custom",
             "./vendor/bin/phpcs --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md --ignore=node_modules,bower_components,vendor ./web/themes/custom"
         ],
+        "code-sniff-fix": [
+            "./vendor/bin/phpcbf --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,info,txt,md --ignore=node_modules,bower_components,vendor ./web/modules/custom",
+            "./vendor/bin/phpcbf --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,info,txt --ignore=node_modules,bower_components,vendor ./web/themes/custom",
+            "./vendor/bin/phpcbf --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,info,txt,md --ignore=node_modules,bower_components,vendor ./web/modules/custom",
+            "./vendor/bin/phpcbf --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,info,txt --ignore=node_modules,bower_components,vendor ./web/themes/custom"
+        ],
         "unit-test": "echo 'No unit test step defined.'",
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "prepare-for-pantheon": "DrupalProject\\composer\\ScriptHandler::prepareForPantheon",

--- a/composer.json
+++ b/composer.json
@@ -55,10 +55,10 @@
         ],
         "lint": "find web/modules/custom web/themes/custom -name '*.php' -exec php -l {} \\;",
         "code-sniff": [
-            "./vendor/bin/phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md --ignore=node_modules,bower_components,vendor ./web/modules/custom",
-            "./vendor/bin/phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md --ignore=node_modules,bower_components,vendor ./web/themes/custom",
-            "./vendor/bin/phpcs --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md --ignore=node_modules,bower_components,vendor ./web/modules/custom",
-            "./vendor/bin/phpcs --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md --ignore=node_modules,bower_components,vendor ./web/themes/custom"
+            "./vendor/bin/phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,info,txt,md --ignore=node_modules,bower_components,vendor ./web/modules/custom",
+            "./vendor/bin/phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,info,txt --ignore=node_modules,bower_components,vendor ./web/themes/custom",
+            "./vendor/bin/phpcs --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,info,txt,md --ignore=node_modules,bower_components,vendor ./web/modules/custom",
+            "./vendor/bin/phpcs --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,info,txt --ignore=node_modules,bower_components,vendor ./web/themes/custom"
         ],
         "code-sniff-fix": [
             "./vendor/bin/phpcbf --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,info,txt,md --ignore=node_modules,bower_components,vendor ./web/modules/custom",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "dealerdirect/phpcodesniffer-composer-installer": ">=0.5.0",
         "dmore/behat-chrome-extension": ">=1.3",
         "drupal/coder": ">=8.3.1",
-        "drupal/config_devel": ">=1.7",
         "drupal/console": ">=1",
         "drupal/drupal-extension": ">=4.1",
         "drupal/upgrade_status": "^3.10",
@@ -34,7 +33,6 @@
         "jcalderonzumba/mink-phantomjs-driver": ">=0.3.1",
         "mglaman/drupal-check": "^1.1",
         "mikey179/vfsstream": ">=1.2",
-        "phpcompatibility/php-compatibility": "^9.3",
         "zaporylie/composer-drupal-optimizations": ">=1.1"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Knowledge Management Collaborative template for Drupal 8",
     "type": "project",
     "license": "GPL-2.0-or-later",
-    "homepage": "https://github.com/thinkshout/km-starter-kit",
+    "homepage": "https://github.com/united-philanthropy-forum/km-starter-kit",
     "repositories": {
         "0": {
             "type": "composer",

--- a/composer.json
+++ b/composer.json
@@ -136,10 +136,12 @@
             "excludes": {
                 "post-install-cmd": [
                     ".ci/test/visual-regression/backstopConfig.js",
+                    ".circleci/config.yml",
                     "README.md"
                 ],
                 "post-update-cmd": [
                     ".ci/test/visual-regression/backstopConfig.js",
+                    ".circleci/config.yml",
                     "README.md"
                 ],
                 "post-create-project-cmd": []

--- a/composer.json
+++ b/composer.json
@@ -109,8 +109,7 @@
         "installer-types": ["bower-asset", "npm-asset", "quicksilver-script"],
         "build-env": {
             "install-cms": [
-                "drush site-install km_collaborative --account-mail={account-mail} --account-name={account-name} --account-pass={account-pass} --site-mail={site-mail} --site-name={site-name} --yes",
-                "drush en kmc_config_part2 -y"
+                "drush site-install km_collaborative --account-mail={account-mail} --account-name={account-name} --account-pass={account-pass} --site-mail={site-mail} --site-name={site-name} --yes"
             ],
             "export-configuration": "drush config-export --yes"
         },


### PR DESCRIPTION
kmc_config_part2 blows up the site build process because of Pantheon memory limits on sandbox sites. Attempts to resolve this by breaking the config up into more "parts" were not going well, so it seems simpler to change the setup process by waiting until after the project creation process to enable this module.

Note that this can't be merged until https://github.com/United-Philanthropy-Forum/km-collaborative/pull/1033 is merged and release 2.0 is out. Then this should be update to point to that release before being merged, along with the targeted php8 branch, which should also merge into the main branch at that time.