### PR TITLE
Php83

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     },
     "require": {
-        "php": "^8.1",
-        "drush/drush": ">10.6",
+        "php": "^8.3",
+        "drush/drush": "^12.0",
         "united-philanthropy-forum/km_collaborative": "dev-main"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,6 @@
         }
     },
     "require": {
-        "php": "^8.3",
-        "drush/drush": "^12.0",
         "united-philanthropy-forum/km_collaborative": "dev-main"
     },
     "require-dev": {


### PR DESCRIPTION
### For the PR creator:
Check off the following boxes before asking someone to review this PR.

- [x] Update the "How to test this branch" instructions below by replacing `php83` with the name of this branch, and 
`kmctest2024` with an example project name.

### What this PR does:
- [x] Stops locking php and drush in this file. This is moved to `km-collaborative` with https://github.com/United-Philanthropy-Forum/km-collaborative/pull/1537

### How to test this branch:
- [x] If you haven't already, run the [One time setup steps](https://github.com/United-Philanthropy-Forum/km-starter-kit/wiki/How-to-test-changes-to-this-starter-kit#one-time)
- [x] Run this:

```yaml
COMPOSER_MEMORY_LIMIT=-1 terminus build:project:create --team='United Philanthropy Forum' --org='United-Philanthropy-Forum' --visibility='private' --stability=dev "united-philanthropy-forum/km-starter-kit:dev-php83" kmctest2024
```

- [x] Validate that a new site exists at https://dev-kmctest2024.pantheonsite.io
- [x] Validate the repo exists at https://github.com/United-Philanthropy-Forum/kmctest2024
- [x] Delete the test environment when you're done, by running `terminus build:env:obliterate kmctest2024`
- [ ] Once this PR is merged, cut a new tag so the `create-project` commands will get the latest and greatest.
