### PR TITLE
Add a file to the build for custom robots.txt additions. #1573.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,10 @@
                 "web-root": "./web"
             },
             "file-mapping": {
-                "[project-root]/.editorconfig": false
+                "[project-root]/.editorconfig": false,
+                "[web-root]/robots.txt": {
+                  "append": "kmc-robots-additions.txt"
+                }
             }
         },
         "enable-patching": true,
@@ -127,11 +130,13 @@
                 "post-install-cmd": [
                     ".ci/test/visual-regression/backstopConfig.js",
                     ".circleci/config.yml",
+                    "kmc-robots-additions.txt",
                     "README.md"
                 ],
                 "post-update-cmd": [
                     ".ci/test/visual-regression/backstopConfig.js",
                     ".circleci/config.yml",
+                    "kmc-robots-additions.txt",
                     "README.md"
                 ],
                 "post-create-project-cmd": []


### PR DESCRIPTION
This works in coordination with https://github.com/United-Philanthropy-Forum/km-collaborative/pull/1574 to add the documents directory (and search results pages) to robots.txt, and allow more robots.txt additions without overwriting drupal's default file, so it can update freely as well.